### PR TITLE
fix(dashboard): move gtag declaration to function body root

### DIFF
--- a/apps/dashboard/app/plugins/gtm.client.ts
+++ b/apps/dashboard/app/plugins/gtm.client.ts
@@ -13,13 +13,13 @@ export default defineNuxtPlugin({
       window.dataLayer = window.dataLayer || [];
 
       // GTM function with better error handling
-      function gtag(...args: any[]) {
+      const gtag = (...args: any[]) => {
         try {
           window.dataLayer?.push(args);
         } catch (error) {
           console.warn("GTM error:", error);
         }
-      }
+      };
 
       // Configure GTM
       gtag("js", new Date());


### PR DESCRIPTION
## Summary\n- addresses #44\n- replaces function declaration with const arrow declaration at the function body root\n- preserves existing GTM behavior and error handling\n\n## Change\nIn , changed:\n- \nto\n- \n\nThis satisfies the Codacy/Error Prone recommendation without altering runtime logic.